### PR TITLE
Changed nginx configuration to default to index

### DIFF
--- a/nginx/edufinder.conf
+++ b/nginx/edufinder.conf
@@ -19,9 +19,9 @@ server {
     ssl_certificate     /etc/nginx/ssl/edufinder.cert.pem;
     ssl_certificate_key /etc/nginx/ssl/edufinder.key.pem;
     charset     utf-8;
-    root        /var/www/frontend/;
-    index                index.html index.htm;
+    root /var/www/frontend/;
     location / {
+        try_files $uri /index.html;
     }
 }
 


### PR DESCRIPTION
If the url doesnt match any file it defaults to the index page.
This is done allow the frontend to handle the routing between pages.